### PR TITLE
Oprava "duchovatění" úvodního obrázku u postu

### DIFF
--- a/_sass/components/BasicPage.scss
+++ b/_sass/components/BasicPage.scss
@@ -266,6 +266,10 @@
     min-height: auto;
     min-height: fit-content;
   }
+
+  .row {
+    position: relative;
+  }
 }
 
 .c-BasicPage-headline-bg {


### PR DESCRIPTION
headline-image je zduplikován a poloprůhledý duplikát je roztažen přez šířku okna, jenže kvůli absolutnímu pozicování se procpe do popředí a vytváří před neprůhledným obrázkem nevzhledný duch. Chování zachyceno nejméně ve Gecku.