### PR TITLE
Create ondrej-vojta.md

### DIFF
--- a/_people/ondrej-vojta.md
+++ b/_people/ondrej-vojta.md
@@ -1,0 +1,23 @@
+---
+uid: ondrej.vojta
+name:     Ondřej Vojta  	# běžně používáné jméno
+titles:
+  before:  
+  after:
+category:                 	# kategorie: praha
+- praha
+img:    # 165 x 220
+description:      	# kratký popis, max 160 znaků
+mail:
+- ondrej.vojta@pirati.cz
+mob:			  +420 736 726 061			 
+profiles:
+  github:       
+  facebook:  https://www.facebook.com/OndrejVojta.Pirati/
+  twitter: 		  
+  flickr:		  
+---
+
+**Ondřej Vojta** (* 20. května 2000) je člen České pirátské strany. Žije v Petrovicích a působí v rámci akčního týmu Pirátů na Praze 15. Je členem komise prevence kriminality rady hl. m. Prahy, také členem povodňové komise na své MČ. Je studentem multimediální tvorby.
+
+V Dolních Měcholupech je členem tamního Sboru dobrovolných hasičů. V rámci „hasičiny" se zapojuje do akcí napříč celou republikou. Je členem pražského pirátského resortního týmu bezpečnosti, zajímá se taktéž o témata volného času mládeže a o sport.


### PR DESCRIPTION
[---]
uid: ondrej.vojta
name:     Ondřej Vojta  	# běžně používáné jméno
titles:
  before:  
  after:
category:                 	# kategorie: praha
- praha
img:    # 165 x 220
description:      	# kratký popis, max 160 znaků
mail:
- ondrej.vojta@pirati.cz
mob:			  +420 736 726 061			 
profiles:
  github:       
  facebook:  https://www.facebook.com/OndrejVojta.Pirati/
  twitter: 		  
  flickr:		  
---

**Ondřej Vojta** (* 20. května 2000) je člen České pirátské strany. Žije v Petrovicích a působí v rámci akčního týmu Pirátů na Praze 15. Je členem komise prevence kriminality rady hl. m. Prahy, také členem povodňové komise na své MČ. Je studentem multimediální tvorby.

V Dolních Měcholupech je členem tamního Sboru dobrovolných hasičů. V rámci „hasičiny" se zapojuje do akcí napříč celou republikou. Je členem pražského pirátského resortního týmu bezpečnosti, zajímá se taktéž o témata volného času mládeže a o sport.